### PR TITLE
feat: Add admin-only 'Unmerge' button to product page

### DIFF
--- a/src/lib/api/products.ts
+++ b/src/lib/api/products.ts
@@ -82,3 +82,12 @@ export async function fetchExternalProductMetadata(internalId: number, externalI
     }
     return response.json();
 }
+
+export async function unmergeProduct(productId: number): Promise<void> {
+    const response = await fetch(`/api/products/${productId}/merge`, {
+        method: 'DELETE',
+    });
+    if (!response.ok) {
+        throw new Error('Failed to unmerge product');
+    }
+}

--- a/src/routes/products/[productId]/+page.svelte
+++ b/src/routes/products/[productId]/+page.svelte
@@ -5,6 +5,7 @@
         fetchExternalProductPrices,
         fetchExternalProductsByInternalId,
         fetchProductPricesById,
+        unmergeProduct,
     } from "$lib/api/products.js";
     import type {
         ExternalProduct,
@@ -31,6 +32,17 @@
     let variants: ProductVariant[] = $state([]);
     let selectedVariants: Record<string, string> = $state({});
     let externalProductMetadatas: Map<number, ExternalProductMetadata[]> = $state(new Map());
+
+    async function handleUnmerge() {
+        try {
+            await unmergeProduct(productId);
+            alert('Product unmerged successfully!');
+            // TODO: Consider redirecting to product list or refreshing data
+        } catch (error) {
+            console.error('Error unmerging product:', error);
+            alert(`Failed to unmerge product. Error: ${error.message}`);
+        }
+    }
 
     async function handleSaveMainProduct() {
         try {
@@ -311,6 +323,7 @@
             <h1>{product?.name}</h1>
             {#if userState.isAdmin}
                 <button class="btn-edit" onclick={startEditingMain}>Edit</button>
+                <button class="btn-unmerge" onclick={handleUnmerge}>Unmerge</button>
             {/if}
         {/if}
         <div class="availability-indicator">
@@ -466,6 +479,23 @@
         .btn-edit:hover {
             background: #f3f4f6;
             border-color: #d1d5db;
+        }
+
+        .btn-unmerge {
+            padding: 0.25rem 0.5rem; /* Similar to btn-edit */
+            background-color: #f87171; /* Tailwind red-400 */
+            border: 1px solid #ef4444; /* Tailwind red-500 */
+            border-radius: 4px; /* Similar to btn-edit */
+            color: white;
+            font-size: 0.875rem; /* Similar to btn-edit */
+            cursor: pointer;
+            transition: all 0.2s;
+            margin-left: 0.5rem; /* Similar to btn-edit */
+        }
+
+        .btn-unmerge:hover {
+            background-color: #ef4444; /* Tailwind red-500 */
+            border-color: #dc2626; /* Tailwind red-600 */
         }
 
         .edit-buttons {


### PR DESCRIPTION
This commit introduces an 'Unmerge' button on the product details page, visible only to administrators.

Key changes include:
- Added an `unmergeProduct` function in `src/lib/api/products.ts` to make a DELETE request to the `/api/products/:productId/merge` endpoint.
- Added the 'Unmerge' button to `src/routes/products/[productId]/+page.svelte`, conditionally rendered for admin users.
- Implemented a `handleUnmerge` function to call the API and display success or error messages using `alert()`.
- Styled the 'Unmerge' button with a distinct red color scheme to indicate a cautionary action, consistent with other UI elements.

This functionality assumes the existence of a backend API endpoint for unmerging products.